### PR TITLE
fix: ensure platform-agnostic macro expansion

### DIFF
--- a/sdp.cabal
+++ b/sdp.cabal
@@ -41,11 +41,14 @@ source-repository head
 ---           | |____ _| |_ | |_/ /| |\ \ | | | || |\ \   | |                ---
 ---           \_____/ \___/ \____/ \_| \_|\_| |_/\_| \_|  \_/                ---
 
+
 Library
   default-language: Haskell2010
   hs-source-dirs:   src
-  
-  ghc-options:      -O2 -Wall -Wcompat
+
+  build-tools: cpphs >=1.19
+
+  ghc-options:    -O2 -Wall -Wcompat -pgmPcpphs -optP--cpp -optP-traditional
   
   build-depends:
     base               >= 4.9 && <   5,


### PR DESCRIPTION
Possible fix for #1. Providing the change that allowed me to build successfully on macOS (both x86_64 and aarch64).

Note that we need to pass `-traditional` to cpphs because otherwise the preprocessor will treat `//` as a c++-style comment.